### PR TITLE
fix: improve save modal accesibility

### DIFF
--- a/src/shared/components/SaveDesignButton/SaveDesignButton.tsx
+++ b/src/shared/components/SaveDesignButton/SaveDesignButton.tsx
@@ -15,7 +15,7 @@ interface SaveDesignButtonProps {
   onMenuHeightChange?: (height: number) => void;
 }
 
-export const SaveDesignButton: React.FC<SaveDesignButtonProps> = ({ 
+export const SaveDesignButton: React.FC<SaveDesignButtonProps> = ({
   getCurrentParameters,
   configuratorType,
   viewport,
@@ -38,7 +38,7 @@ export const SaveDesignButton: React.FC<SaveDesignButtonProps> = ({
 
         const clickedInsideMenu = saveMenu?.contains(clickTarget);
         const clickedInsideButton = saveButton?.contains(clickTarget);
-        
+
         if (!clickedInsideMenu && !clickedInsideButton) {
           setIsModalOpen(false);
         }
@@ -46,11 +46,11 @@ export const SaveDesignButton: React.FC<SaveDesignButtonProps> = ({
     };
 
     if (isModalOpen) {
-      window.addEventListener('mousedown', handleClickOutside, true);
+      window.addEventListener('click', handleClickOutside, true);
     }
 
     return () => {
-      window.removeEventListener('mousedown', handleClickOutside, true);
+      window.removeEventListener('click', handleClickOutside, true);
     };
   }, [isModalOpen]);
 
@@ -102,17 +102,17 @@ export const SaveDesignButton: React.FC<SaveDesignButtonProps> = ({
     try {
       console.log('1. Getting parameters...');
       const parameters = getCurrentParameters();
-      
+
       console.log('2. Capturing screenshot...');
       const screenshotData = await captureScreenshot();
       if (!screenshotData) {
         throw new Error('Failed to capture screenshot');
       }
       console.log('Screenshot data length:', screenshotData.length);
-      
+
       console.log('3. Getting auth token...');
       const token = await getAccessTokenSilently();
-      
+
       const design: Omit<SavedDesign, 'id' | 'created_at'> = {
         name: designName,
         user_id: user.sub,
@@ -121,11 +121,11 @@ export const SaveDesignButton: React.FC<SaveDesignButtonProps> = ({
         configurator_type: configuratorType as ConfiguratorType,
         thumbnail_url: screenshotData
       };
-      
+
       console.log('4. Saving design...');
       const savedDesign = await DesignStorageService.saveDesign(design, token);
       console.log('5. Design saved:', savedDesign);
-      
+
       setIsModalOpen(false);
       setDesignName('');
     } catch (error) {
@@ -147,9 +147,9 @@ export const SaveDesignButton: React.FC<SaveDesignButtonProps> = ({
               aria-label="Save design"
             >
               <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <path d="M19 21H5C4.46957 21 3.96086 20.7893 3.58579 20.4142C3.21071 20.0391 3 19.5304 3 19V5C3 4.46957 3.21071 3.96086 3.58579 3.58579C3.96086 3.21071 4.46957 3 5 3H16L21 8V19C21 19.5304 20.7893 20.0391 20.4142 20.4142C20.0391 20.7893 19.5304 21 19 21Z" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-                <path d="M17 21V13H7V21" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-                <path d="M7 3V8H15" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+                <path d="M19 21H5C4.46957 21 3.96086 20.7893 3.58579 20.4142C3.21071 20.0391 3 19.5304 3 19V5C3 4.46957 3.21071 3.96086 3.58579 3.58579C3.96086 3.21071 4.46957 3 5 3H16L21 8V19C21 19.5304 20.7893 20.0391 20.4142 20.4142C20.0391 20.7893 19.5304 21 19 21Z" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                <path d="M17 21V13H7V21" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                <path d="M7 3V8H15" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
               </svg>
               <span className="save-button-text">Save</span>
             </button>
@@ -166,9 +166,9 @@ export const SaveDesignButton: React.FC<SaveDesignButtonProps> = ({
             aria-label="Save design"
           >
             <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path d="M19 21H5C4.46957 21 3.96086 20.7893 3.58579 20.4142C3.21071 20.0391 3 19.5304 3 19V5C3 4.46957 3.21071 3.96086 3.58579 3.58579C3.96086 3.21071 4.46957 3 5 3H16L21 8V19C21 19.5304 20.7893 20.0391 20.4142 20.4142C20.0391 20.7893 19.5304 21 19 21Z" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-              <path d="M17 21V13H7V21" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-              <path d="M7 3V8H15" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+              <path d="M19 21H5C4.46957 21 3.96086 20.7893 3.58579 20.4142C3.21071 20.0391 3 19.5304 3 19V5C3 4.46957 3.21071 3.96086 3.58579 3.58579C3.96086 3.21071 4.46957 3 5 3H16L21 8V19C21 19.5304 20.7893 20.0391 20.4142 20.4142C20.0391 20.7893 19.5304 21 19 21Z" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+              <path d="M17 21V13H7V21" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+              <path d="M7 3V8H15" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
             </svg>
             <span className="save-button-text">Save</span>
           </button>
@@ -176,6 +176,9 @@ export const SaveDesignButton: React.FC<SaveDesignButtonProps> = ({
 
         {isModalOpen && (
           <div className="save-menu" ref={menuRef}>
+            <button className="close-button" onClick={() => setIsModalOpen(false)} aria-label="Close">
+              &times;
+            </button>
             <h3 className="save-title">Save Your Design</h3>
             <div className="save-form">
               <input
@@ -185,6 +188,11 @@ export const SaveDesignButton: React.FC<SaveDesignButtonProps> = ({
                 onChange={(e) => setDesignName(e.currentTarget.value)}
                 placeholder="Enter a name for your design"
                 disabled={isSaving}
+                onKeyPress={(e) => {
+                  if (e.key === 'Enter' && designName.trim() && !isSaving) {
+                    handleSave();
+                  }
+                }}
               />
               <div className="save-button-container">
                 <button


### PR DESCRIPTION
Small PR to test that everything works.

Improved the accesivbility of the save button modal:

- Add close button to the modal s.t. you can close with keyboard, and also add an intuitive way of closing the modal
- Add possibilty to save with enter button after typing in name
- Change eventlistener to use click instead of mouse down such that also clicking on the 3D area closes the save modal. Before this change you had to click on the header or parameter panel to close the modal by clicking outside.

<img width="215" alt="image" src="https://github.com/user-attachments/assets/8cfb499e-f43a-4261-9be2-475353238d49" />
