### PR TITLE
fix: Add padding to error boundary

### DIFF
--- a/src/shared/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/shared/components/ErrorBoundary/ErrorBoundary.tsx
@@ -33,7 +33,7 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
   render() {
     if (this.state.hasError && this.state.error) {  // Check for both
       return this.props.fallback || (
-        <div style={{ padding: '20px', textAlign: 'center' }}>
+        <div style={{ padding: '80px', textAlign: 'center' }}>
           <h1>Something went wrong</h1>
           <p>Please try refreshing the page</p>
           {process.env.NODE_ENV !== 'production' && (


### PR DESCRIPTION
Added padding to prevent error message being displayed behind header.

Before and after:

<img width="674" alt="image" src="https://github.com/user-attachments/assets/fb26bffc-4dff-4189-92da-92a85ecb9692" />

<img width="680" alt="image" src="https://github.com/user-attachments/assets/31f9b7a9-60a8-4d74-a20a-f64769fe71cc" />
