### PR TITLE
fix: save alignment

### DIFF
--- a/src/dynamic/components/ConfiguratorPage/ConfiguratorPage.css
+++ b/src/dynamic/components/ConfiguratorPage/ConfiguratorPage.css
@@ -91,7 +91,7 @@
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  gap: 0.8rem;
+  gap: 0.5rem;
   z-index: 1002;
   pointer-events: none;
   height: 2rem;
@@ -99,7 +99,7 @@
 
 /* When share menu is open, adjust panel position */
 .parameter-panel-container.share-open {
-  transform: translateY(calc(var(--share-menu-height, 0px) - 2em));
+  transform: translateY(calc(var(--share-menu-height, 0px) - 4em));
   transition: transform 0.5s ease;
 }
 

--- a/src/dynamic/components/ConfiguratorPage/ConfiguratorPage.css
+++ b/src/dynamic/components/ConfiguratorPage/ConfiguratorPage.css
@@ -73,37 +73,39 @@
 
   position: fixed;
   bottom: 2vh;
-  right: 3vh;
+  right: 2vh;
   width: 22em; /* Match the width from viewer container */
   height: 85vh; /* Increased from 35vh to 45vh */
-  margin-top: 10vh; /* Add top padding to avoid share button */
+  margin-top: calc(2rem + 5vh); /* Add top padding to avoid share button */
   display: flex;
   flex-direction: column;
   justify-content: flex-end;
   z-index: 100;
+  transition: transform 0.5s ease;
 }
 
 .top-right-buttons {
   position: fixed;
-  top: 1.5rem;
+  top: 22px;
   right: 2vh;
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  gap: 1rem;
+  gap: 0.8rem;
   z-index: 1002;
   pointer-events: none;
+  height: 2rem;
 }
 
 /* When share menu is open, adjust panel position */
 .parameter-panel-container.share-open {
-  transform: translateY(calc(var(--share-menu-height, 0px) - 5vh));
+  transform: translateY(calc(var(--share-menu-height, 0px) - 2em));
   transition: transform 0.5s ease;
 }
 
 /* When save menu is open, adjust panel position */
 .parameter-panel-container.save-open {
-  transform: translateY(calc(var(--save-menu-height, 0px) - 5vh));
+  transform: translateY(calc(var(--save-menu-height, 0px) - 2em));
   transition: transform 0.5s ease;
 }
 

--- a/src/dynamic/components/ConfiguratorPage/ConfiguratorPage.tsx
+++ b/src/dynamic/components/ConfiguratorPage/ConfiguratorPage.tsx
@@ -47,7 +47,9 @@ const ConfiguratorPage: React.FC = () => {
   const [showDimensions, setShowDimensions] = useState(false);
   const [isShareMenuOpen, setIsShareMenuOpen] = useState(false);
   const [shareMenuHeight, setShareMenuHeight] = useState<number>(15);
-  
+  const [isSaveMenuOpen, setIsSaveMenuOpen] = useState(false);
+  const [saveMenuHeight, setSaveMenuHeight] = useState<number>(15);
+
   // Reference to track component mount state
   const isMounted = useRef(true);
 
@@ -198,8 +200,8 @@ const ConfiguratorPage: React.FC = () => {
             getCurrentParameters={() => session?.parameterValues || {}}
             configuratorType={CONFIGURATOR_TYPES.DEFAULT}
             viewport={viewport}
-            onMenuOpen={setIsShareMenuOpen}
-            onMenuHeightChange={setShareMenuHeight}
+            onMenuOpen={setIsSaveMenuOpen}
+            onMenuHeightChange={setSaveMenuHeight}
             session={session}
           />
           <ShareButton 
@@ -225,7 +227,7 @@ const ConfiguratorPage: React.FC = () => {
           </div>
           
           {/* Parameter panel container */}
-          <div className={`parameter-panel-container ${isShareMenuOpen ? 'share-open' : ''}`}>
+          <div className={`parameter-panel-container ${isShareMenuOpen && 'share-open'} ${isSaveMenuOpen && 'save-open'}`}>
             <Suspense fallback={null}>
               <ParameterPanel
                   key={JSON.stringify(session?.parameterValues)}

--- a/src/dynamic/components/ConfiguratorPage/components/Share/ShareButton.css
+++ b/src/dynamic/components/ConfiguratorPage/components/Share/ShareButton.css
@@ -66,9 +66,15 @@
     from {
         opacity: 0;
         transform: scale(0.95);
+        background: #000000;
+        color: white;
+        font-weight: 700;
     }
     to {
         opacity: 1;
         transform: scale(1);
+        background: #000000;
+        color: white; 
+        font-weight: 700;
     }
 }

--- a/src/dynamic/components/ConfiguratorPage/components/Share/ShareButton.css
+++ b/src/dynamic/components/ConfiguratorPage/components/Share/ShareButton.css
@@ -4,7 +4,6 @@
     pointer-events: all;
     height: 3.5rem;
     position: relative;
-    z-index: 1;
 }
 
 .share-button-container {

--- a/src/dynamic/components/ConfiguratorPage/components/Share/ShareMenu.css
+++ b/src/dynamic/components/ConfiguratorPage/components/Share/ShareMenu.css
@@ -6,7 +6,7 @@
   animation: menuAppear 0.5s ease;
   border: 1px solid #6a6a6a;
   position: fixed;
-  top: 10px;  /* Align with share button */
+  top: var(--header-height, 75px);
   right: 2vh; /* Align with share button */
   z-index: 1001;
   padding: 1.5rem;
@@ -26,7 +26,9 @@
 
 /* Ensure the button is hidden when menu is open */
 .share-container.menu-open .share-button {
-  opacity: 0;
+  background: #000000;
+  color: white;
+  font-weight: 700;
 }
 
 /* Scrollbar styles */

--- a/src/dynamic/components/ConfiguratorPage/components/Share/ShareMenu.css
+++ b/src/dynamic/components/ConfiguratorPage/components/Share/ShareMenu.css
@@ -5,9 +5,9 @@
   backdrop-filter: blur(10px);
   animation: menuAppear 0.5s ease;
   border: 1px solid #6a6a6a;
-  position: absolute;
-  top: 0;  /* Align with share button */
-  right: 0; /* Align with share button */
+  position: fixed;
+  top: 10px;  /* Align with share button */
+  right: 2vh; /* Align with share button */
   z-index: 1001;
   padding: 1.5rem;
 }

--- a/src/dynamic/components/ConfiguratorPage/components/Share/ShareMenu.tsx
+++ b/src/dynamic/components/ConfiguratorPage/components/Share/ShareMenu.tsx
@@ -38,6 +38,7 @@ const ShareMenu: React.FC<ShareMenuProps> = ({ onClose, session, viewport,isMenu
       {activeView === 'main' && (
         <>
           <h3 className="share-title">Share this bike</h3>
+          <button className="close-button" onClick={onClose}>×</button>
           <div className="share-options">
             <div className="share-option-button-container-ar">
               <button

--- a/src/shared/components/SaveDesignButton/SaveDesignButton.css
+++ b/src/shared/components/SaveDesignButton/SaveDesignButton.css
@@ -19,6 +19,12 @@
     width: 100%;
 }
 
+/* Add this style for save button when menu is open */
+.save-container.menu-open .save-button {
+  background: #000000;
+  color: white;
+  font-weight: 700;
+}
 .save-button {
     display: flex;
     align-items: center;
@@ -72,7 +78,7 @@
   animation: menuAppear 0.5s ease;
   border: 1px solid #6a6a6a;
   position: fixed;
-  top: 10px;
+  top: 75px;
   right: 2vh;
   z-index: 1003;
   padding: 1.5rem;
@@ -139,8 +145,3 @@
     border-radius: 1rem;
   }
 }
-
-/* Ensure the button is hidden when menu is open */
-.save-container.menu-open .save-button {
-  opacity: 0;
-} 

--- a/src/shared/components/SaveDesignButton/SaveDesignButton.css
+++ b/src/shared/components/SaveDesignButton/SaveDesignButton.css
@@ -71,9 +71,9 @@
   backdrop-filter: blur(10px);
   animation: menuAppear 0.5s ease;
   border: 1px solid #6a6a6a;
-  position: absolute;
-  top: 0;
-  right: 0;
+  position: fixed;
+  top: 10px;
+  right: 2vh;
   z-index: 1003;
   padding: 1.5rem;
 }

--- a/src/shared/components/SaveDesignButton/SaveDesignButton.tsx
+++ b/src/shared/components/SaveDesignButton/SaveDesignButton.tsx
@@ -19,6 +19,7 @@ export const SaveDesignButton: React.FC<SaveDesignButtonProps> = ({
   getCurrentParameters,
   configuratorType,
   viewport,
+  onMenuOpen,
   onMenuHeightChange
 }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -28,6 +29,15 @@ export const SaveDesignButton: React.FC<SaveDesignButtonProps> = ({
   const menuRef = useRef<HTMLDivElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    onMenuOpen(isModalOpen);
+    if (isModalOpen) {
+      onMenuHeightChange?.(15);
+    } else {
+      onMenuHeightChange?.(0);
+    }
+  }, [isModalOpen, onMenuOpen, onMenuHeightChange]);
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {


### PR DESCRIPTION
- Align top right buttons better with header and panel
- Align share and save menu better with buttons and panel
- Make panel slide down when save menu opens
- Add slide animation when the menu closes as well
- Add close button to share modal to make it more similar to save